### PR TITLE
Fix building on new gcc versions

### DIFF
--- a/week1/ints/exceptions/Makefile
+++ b/week1/ints/exceptions/Makefile
@@ -4,7 +4,7 @@ LD ?= ld
 CFLAGS := -g -m64 -mno-red-zone -mno-mmx -mno-sse -mno-sse2 -ffreestanding \
 	-mcmodel=kernel -Wall -Wextra -Werror -pedantic -std=c99 \
 	-Wframe-larger-than=1024 -Wstack-usage=1024 \
-	-Wno-unknown-warning-option $(if $(DEBUG),-DDEBUG)
+	-Wno-unknown-warning-option -fno-pic $(if $(DEBUG),-DDEBUG)
 LFLAGS := -nostdlib -z max-page-size=0x1000
 
 INC := ./inc

--- a/week1/ints/exceptions/src/print.c
+++ b/week1/ints/exceptions/src/print.c
@@ -93,10 +93,13 @@ static int decode_format(const char **fmt_ptr)
 		switch ((c = *fmt++)) {
 		case 'p':
 			spec |= FMT_LONG;
+			// fallthrough
 		case 'x': case 'X': case 'o':
 			spec |= c == 'o' ? FMT_OCT : FMT_HEX;
+			// fallthrough
 		case 'u':
 			spec |= FMT_UNSIGNED;
+			// fallthrough
 		case 'd': case 'i':
 			type = FMT_INT;
 			break;

--- a/week1/ints/interrupts/Makefile
+++ b/week1/ints/interrupts/Makefile
@@ -4,7 +4,7 @@ LD ?= ld
 CFLAGS := -g -m64 -mno-red-zone -mno-mmx -mno-sse -mno-sse2 -ffreestanding \
 	-mcmodel=kernel -Wall -Wextra -Werror -pedantic -std=c99 \
 	-Wframe-larger-than=1024 -Wstack-usage=1024 \
-	-Wno-unknown-warning-option $(if $(DEBUG),-DDEBUG)
+	-Wno-unknown-warning-option -Wno-unused-const-variable -fno-pic $(if $(DEBUG),-DDEBUG)
 LFLAGS := -nostdlib -z max-page-size=0x1000
 
 INC := ./inc

--- a/week1/ints/interrupts/src/print.c
+++ b/week1/ints/interrupts/src/print.c
@@ -93,10 +93,13 @@ static int decode_format(const char **fmt_ptr)
 		switch ((c = *fmt++)) {
 		case 'p':
 			spec |= FMT_LONG;
+			// fallthrough
 		case 'x': case 'X': case 'o':
 			spec |= c == 'o' ? FMT_OCT : FMT_HEX;
+			// fallthrough
 		case 'u':
 			spec |= FMT_UNSIGNED;
+			// fallthrough
 		case 'd': case 'i':
 			type = FMT_INT;
 			break;

--- a/week1/load/multiboot-boot/Makefile
+++ b/week1/load/multiboot-boot/Makefile
@@ -4,7 +4,7 @@ LD ?= ld
 CFLAGS := -g -m64 -mno-red-zone -mno-mmx -mno-sse -mno-sse2 -ffreestanding \
 	-mcmodel=kernel -Wall -Wextra -Werror -pedantic -std=c99 \
 	-Wframe-larger-than=1024 -Wstack-usage=1024 \
-	-Wno-unknown-warning-option $(if $(DEBUG),-DDEBUG)
+	-Wno-unknown-warning-option -fno-pic $(if $(DEBUG),-DDEBUG)
 LFLAGS := -nostdlib -z max-page-size=0x1000
 
 INC := ./inc

--- a/week1/load/multiboot-boot/src/print.c
+++ b/week1/load/multiboot-boot/src/print.c
@@ -93,10 +93,13 @@ static int decode_format(const char **fmt_ptr)
 		switch ((c = *fmt++)) {
 		case 'p':
 			spec |= FMT_LONG;
+			// fallthrough
 		case 'x': case 'X': case 'o':
 			spec |= c == 'o' ? FMT_OCT : FMT_HEX;
+			// fallthrough
 		case 'u':
 			spec |= FMT_UNSIGNED;
+			// fallthrough
 		case 'd': case 'i':
 			type = FMT_INT;
 			break;

--- a/week2/alloc/buddy-allocator/Makefile
+++ b/week2/alloc/buddy-allocator/Makefile
@@ -4,7 +4,7 @@ LD ?= ld
 CFLAGS := -g -m64 -mno-red-zone -mno-mmx -mno-sse -mno-sse2 -ffreestanding \
 	-mcmodel=kernel -Wall -Wextra -Werror -pedantic -std=c99 \
 	-Wframe-larger-than=1024 -Wstack-usage=1024 \
-	-Wno-unknown-warning-option $(if $(DEBUG),-DDEBUG)
+	-Wno-unknown-warning-option -fno-pic $(if $(DEBUG),-DDEBUG)
 LFLAGS := -nostdlib -z max-page-size=0x1000
 
 INC := ./inc

--- a/week2/alloc/buddy-allocator/src/print.c
+++ b/week2/alloc/buddy-allocator/src/print.c
@@ -93,10 +93,13 @@ static int decode_format(const char **fmt_ptr)
 		switch ((c = *fmt++)) {
 		case 'p':
 			spec |= FMT_LONG;
+			// fallthrough
 		case 'x': case 'X': case 'o':
 			spec |= c == 'o' ? FMT_OCT : FMT_HEX;
+			// fallthrough
 		case 'u':
 			spec |= FMT_UNSIGNED;
+			// fallthrough
 		case 'd': case 'i':
 			type = FMT_INT;
 			break;

--- a/week2/log_mem/bootstrap-allocator/Makefile
+++ b/week2/log_mem/bootstrap-allocator/Makefile
@@ -4,7 +4,7 @@ LD ?= ld
 CFLAGS := -g -m64 -mno-red-zone -mno-mmx -mno-sse -mno-sse2 -ffreestanding \
 	-mcmodel=kernel -Wall -Wextra -Werror -pedantic -std=c99 \
 	-Wframe-larger-than=1024 -Wstack-usage=1024 \
-	-Wno-unknown-warning-option $(if $(DEBUG),-DDEBUG)
+	-Wno-unknown-warning-option -fno-pic $(if $(DEBUG),-DDEBUG)
 LFLAGS := -nostdlib -z max-page-size=0x1000
 
 INC := ./inc

--- a/week2/log_mem/bootstrap-allocator/src/print.c
+++ b/week2/log_mem/bootstrap-allocator/src/print.c
@@ -93,10 +93,13 @@ static int decode_format(const char **fmt_ptr)
 		switch ((c = *fmt++)) {
 		case 'p':
 			spec |= FMT_LONG;
+			// fallthrough
 		case 'x': case 'X': case 'o':
 			spec |= c == 'o' ? FMT_OCT : FMT_HEX;
+			// fallthrough
 		case 'u':
 			spec |= FMT_UNSIGNED;
+			// fallthrough
 		case 'd': case 'i':
 			type = FMT_INT;
 			break;

--- a/week2/log_mem/initial-paging/Makefile
+++ b/week2/log_mem/initial-paging/Makefile
@@ -4,7 +4,7 @@ LD ?= ld
 CFLAGS := -g -m64 -mno-red-zone -mno-mmx -mno-sse -mno-sse2 -ffreestanding \
 	-mcmodel=kernel -Wall -Wextra -Werror -pedantic -std=c99 \
 	-Wframe-larger-than=1024 -Wstack-usage=1024 \
-	-Wno-unknown-warning-option $(if $(DEBUG),-DDEBUG)
+	-Wno-unknown-warning-option -fno-pic $(if $(DEBUG),-DDEBUG)
 LFLAGS := -nostdlib -z max-page-size=0x1000
 
 INC := ./inc

--- a/week2/log_mem/initial-paging/src/print.c
+++ b/week2/log_mem/initial-paging/src/print.c
@@ -93,10 +93,13 @@ static int decode_format(const char **fmt_ptr)
 		switch ((c = *fmt++)) {
 		case 'p':
 			spec |= FMT_LONG;
+			// fallthrough
 		case 'x': case 'X': case 'o':
 			spec |= c == 'o' ? FMT_OCT : FMT_HEX;
+			// fallthrough
 		case 'u':
 			spec |= FMT_UNSIGNED;
+			// fallthrough
 		case 'd': case 'i':
 			type = FMT_INT;
 			break;

--- a/week2/phys_mem/physmem-map/Makefile
+++ b/week2/phys_mem/physmem-map/Makefile
@@ -4,7 +4,7 @@ LD ?= ld
 CFLAGS := -g -m64 -mno-red-zone -mno-mmx -mno-sse -mno-sse2 -ffreestanding \
 	-mcmodel=kernel -Wall -Wextra -Werror -pedantic -std=c99 \
 	-Wframe-larger-than=1024 -Wstack-usage=1024 \
-	-Wno-unknown-warning-option $(if $(DEBUG),-DDEBUG)
+	-Wno-unknown-warning-option -fno-pic $(if $(DEBUG),-DDEBUG)
 LFLAGS := -nostdlib -z max-page-size=0x1000
 
 INC := ./inc

--- a/week2/phys_mem/physmem-map/src/print.c
+++ b/week2/phys_mem/physmem-map/src/print.c
@@ -93,10 +93,13 @@ static int decode_format(const char **fmt_ptr)
 		switch ((c = *fmt++)) {
 		case 'p':
 			spec |= FMT_LONG;
+			// fallthrough
 		case 'x': case 'X': case 'o':
 			spec |= c == 'o' ? FMT_OCT : FMT_HEX;
+			// fallthrough
 		case 'u':
 			spec |= FMT_UNSIGNED;
+			// fallthrough
 		case 'd': case 'i':
 			type = FMT_INT;
 			break;

--- a/week3/threads/threads/Makefile
+++ b/week3/threads/threads/Makefile
@@ -4,7 +4,7 @@ LD ?= ld
 CFLAGS := -g -m64 -mno-red-zone -mno-mmx -mno-sse -mno-sse2 -ffreestanding \
 	-mcmodel=kernel -Wall -Wextra -Werror -pedantic -std=c99 \
 	-Wframe-larger-than=1024 -Wstack-usage=1024 \
-	-Wno-unknown-warning-option $(if $(DEBUG),-DDEBUG)
+	-Wno-unknown-warning-option -Wno-unused-const-variable -fno-pic $(if $(DEBUG),-DDEBUG)
 LFLAGS := -nostdlib -z max-page-size=0x1000
 
 INC := ./inc

--- a/week3/threads/threads/src/print.c
+++ b/week3/threads/threads/src/print.c
@@ -93,10 +93,13 @@ static int decode_format(const char **fmt_ptr)
 		switch ((c = *fmt++)) {
 		case 'p':
 			spec |= FMT_LONG;
+			// fallthrough
 		case 'x': case 'X': case 'o':
 			spec |= c == 'o' ? FMT_OCT : FMT_HEX;
+			// fallthrough
 		case 'u':
 			spec |= FMT_UNSIGNED;
+			// fallthrough
 		case 'd': case 'i':
 			type = FMT_INT;
 			break;

--- a/week4/sync/conditions/Makefile
+++ b/week4/sync/conditions/Makefile
@@ -4,7 +4,7 @@ LD ?= ld
 CFLAGS := -g -m64 -mno-red-zone -mno-mmx -mno-sse -mno-sse2 -ffreestanding \
 	-mcmodel=kernel -Wall -Wextra -Werror -pedantic -std=c99 \
 	-Wframe-larger-than=1024 -Wstack-usage=1024 \
-	-Wno-unknown-warning-option $(if $(DEBUG),-DDEBUG)
+	-Wno-unknown-warning-option -Wno-unused-const-variable -fno-pic $(if $(DEBUG),-DDEBUG)
 LFLAGS := -nostdlib -z max-page-size=0x1000
 
 INC := ./inc

--- a/week4/sync/conditions/src/print.c
+++ b/week4/sync/conditions/src/print.c
@@ -93,10 +93,13 @@ static int decode_format(const char **fmt_ptr)
 		switch ((c = *fmt++)) {
 		case 'p':
 			spec |= FMT_LONG;
+			// fallthrough
 		case 'x': case 'X': case 'o':
 			spec |= c == 'o' ? FMT_OCT : FMT_HEX;
+			// fallthrough
 		case 'u':
 			spec |= FMT_UNSIGNED;
+			// fallthrough
 		case 'd': case 'i':
 			type = FMT_INT;
 			break;

--- a/week4/sync/locks/Makefile
+++ b/week4/sync/locks/Makefile
@@ -4,7 +4,7 @@ LD ?= ld
 CFLAGS := -g -m64 -mno-red-zone -mno-mmx -mno-sse -mno-sse2 -ffreestanding \
 	-mcmodel=kernel -Wall -Wextra -Werror -pedantic -std=c99 \
 	-Wframe-larger-than=1024 -Wstack-usage=1024 \
-	-Wno-unknown-warning-option $(if $(DEBUG),-DDEBUG)
+	-Wno-unknown-warning-option -Wno-unused-const-variable -fno-pic $(if $(DEBUG),-DDEBUG)
 LFLAGS := -nostdlib -z max-page-size=0x1000
 
 INC := ./inc

--- a/week4/sync/locks/src/print.c
+++ b/week4/sync/locks/src/print.c
@@ -93,10 +93,13 @@ static int decode_format(const char **fmt_ptr)
 		switch ((c = *fmt++)) {
 		case 'p':
 			spec |= FMT_LONG;
+			// fallthrough
 		case 'x': case 'X': case 'o':
 			spec |= c == 'o' ? FMT_OCT : FMT_HEX;
+			// fallthrough
 		case 'u':
 			spec |= FMT_UNSIGNED;
+			// fallthrough
 		case 'd': case 'i':
 			type = FMT_INT;
 			break;

--- a/week4/sync/mutexes/Makefile
+++ b/week4/sync/mutexes/Makefile
@@ -4,7 +4,7 @@ LD ?= ld
 CFLAGS := -g -m64 -mno-red-zone -mno-mmx -mno-sse -mno-sse2 -ffreestanding \
 	-mcmodel=kernel -Wall -Wextra -Werror -pedantic -std=c99 \
 	-Wframe-larger-than=1024 -Wstack-usage=1024 \
-	-Wno-unknown-warning-option $(if $(DEBUG),-DDEBUG)
+	-Wno-unknown-warning-option -Wno-unused-const-variable -fno-pic $(if $(DEBUG),-DDEBUG)
 LFLAGS := -nostdlib -z max-page-size=0x1000
 
 INC := ./inc

--- a/week4/sync/mutexes/src/print.c
+++ b/week4/sync/mutexes/src/print.c
@@ -93,10 +93,13 @@ static int decode_format(const char **fmt_ptr)
 		switch ((c = *fmt++)) {
 		case 'p':
 			spec |= FMT_LONG;
+			// fallthrough
 		case 'x': case 'X': case 'o':
 			spec |= c == 'o' ? FMT_OCT : FMT_HEX;
+			// fallthrough
 		case 'u':
 			spec |= FMT_UNSIGNED;
+			// fallthrough
 		case 'd': case 'i':
 			type = FMT_INT;
 			break;

--- a/week5/initramfs/Makefile
+++ b/week5/initramfs/Makefile
@@ -4,7 +4,7 @@ LD ?= ld
 CFLAGS := -g -m64 -mno-red-zone -mno-mmx -mno-sse -mno-sse2 -ffreestanding \
 	-mcmodel=kernel -Wall -Wextra -Werror -pedantic -std=c99 \
 	-Wframe-larger-than=1024 -Wstack-usage=1024 \
-	-Wno-unknown-warning-option $(if $(DEBUG),-DDEBUG)
+	-Wno-unknown-warning-option -Wno-unused-const-variable -fno-pic $(if $(DEBUG),-DDEBUG)
 LFLAGS := -nostdlib -z max-page-size=0x1000
 
 INC := ./inc

--- a/week5/initramfs/src/print.c
+++ b/week5/initramfs/src/print.c
@@ -93,10 +93,13 @@ static int decode_format(const char **fmt_ptr)
 		switch ((c = *fmt++)) {
 		case 'p':
 			spec |= FMT_LONG;
+			// fallthrough
 		case 'x': case 'X': case 'o':
 			spec |= c == 'o' ? FMT_OCT : FMT_HEX;
+			// fallthrough
 		case 'u':
 			spec |= FMT_UNSIGNED;
+			// fallthrough
 		case 'd': case 'i':
 			type = FMT_INT;
 			break;

--- a/week5/load/Makefile
+++ b/week5/load/Makefile
@@ -4,7 +4,7 @@ LD ?= ld
 CFLAGS := -g -m64 -mno-red-zone -mno-mmx -mno-sse -mno-sse2 -ffreestanding \
 	-mcmodel=kernel -Wall -Wextra -Werror -pedantic -std=c99 \
 	-Wframe-larger-than=1024 -Wstack-usage=1024 \
-	-Wno-unknown-warning-option $(if $(DEBUG),-DDEBUG)
+	-Wno-unknown-warning-option -Wno-unused-const-variable -fno-pic $(if $(DEBUG),-DDEBUG)
 LFLAGS := -nostdlib -z max-page-size=0x1000
 
 INC := ./inc

--- a/week5/load/src/print.c
+++ b/week5/load/src/print.c
@@ -93,10 +93,13 @@ static int decode_format(const char **fmt_ptr)
 		switch ((c = *fmt++)) {
 		case 'p':
 			spec |= FMT_LONG;
+			// fallthrough
 		case 'x': case 'X': case 'o':
 			spec |= c == 'o' ? FMT_OCT : FMT_HEX;
+			// fallthrough
 		case 'u':
 			spec |= FMT_UNSIGNED;
+			// fallthrough
 		case 'd': case 'i':
 			type = FMT_INT;
 			break;

--- a/week5/mm/Makefile
+++ b/week5/mm/Makefile
@@ -4,7 +4,7 @@ LD ?= ld
 CFLAGS := -g -m64 -mno-red-zone -mno-mmx -mno-sse -mno-sse2 -ffreestanding \
 	-mcmodel=kernel -Wall -Wextra -Werror -pedantic -std=c99 \
 	-Wframe-larger-than=1024 -Wstack-usage=1024 \
-	-Wno-unknown-warning-option $(if $(DEBUG),-DDEBUG)
+	-Wno-unknown-warning-option -Wno-unused-const-variable -fno-pic $(if $(DEBUG),-DDEBUG)
 LFLAGS := -nostdlib -z max-page-size=0x1000
 
 INC := ./inc

--- a/week5/mm/src/print.c
+++ b/week5/mm/src/print.c
@@ -93,10 +93,13 @@ static int decode_format(const char **fmt_ptr)
 		switch ((c = *fmt++)) {
 		case 'p':
 			spec |= FMT_LONG;
+			// fallthrough
 		case 'x': case 'X': case 'o':
 			spec |= c == 'o' ? FMT_OCT : FMT_HEX;
+			// fallthrough
 		case 'u':
 			spec |= FMT_UNSIGNED;
+			// fallthrough
 		case 'd': case 'i':
 			type = FMT_INT;
 			break;

--- a/week5/syscall/Makefile
+++ b/week5/syscall/Makefile
@@ -4,7 +4,7 @@ LD ?= ld
 CFLAGS := -g -m64 -mno-red-zone -mno-mmx -mno-sse -mno-sse2 -ffreestanding \
 	-mcmodel=kernel -Wall -Wextra -Werror -pedantic -std=c99 \
 	-Wframe-larger-than=1024 -Wstack-usage=1024 \
-	-Wno-unknown-warning-option $(if $(DEBUG),-DDEBUG)
+	-Wno-unknown-warning-option -Wno-unused-const-variable -fno-pic $(if $(DEBUG),-DDEBUG)
 LFLAGS := -nostdlib -z max-page-size=0x1000
 
 INC := ./inc

--- a/week5/syscall/src/print.c
+++ b/week5/syscall/src/print.c
@@ -93,10 +93,13 @@ static int decode_format(const char **fmt_ptr)
 		switch ((c = *fmt++)) {
 		case 'p':
 			spec |= FMT_LONG;
+			// fallthrough
 		case 'x': case 'X': case 'o':
 			spec |= c == 'o' ? FMT_OCT : FMT_HEX;
+			// fallthrough
 		case 'u':
 			spec |= FMT_UNSIGNED;
+			// fallthrough
 		case 'd': case 'i':
 			type = FMT_INT;
 			break;

--- a/week5/tss/Makefile
+++ b/week5/tss/Makefile
@@ -4,7 +4,7 @@ LD ?= ld
 CFLAGS := -g -m64 -mno-red-zone -mno-mmx -mno-sse -mno-sse2 -ffreestanding \
 	-mcmodel=kernel -Wall -Wextra -Werror -pedantic -std=c99 \
 	-Wframe-larger-than=1024 -Wstack-usage=1024 \
-	-Wno-unknown-warning-option $(if $(DEBUG),-DDEBUG)
+	-Wno-unknown-warning-option -Wno-unused-const-variable -fno-pic $(if $(DEBUG),-DDEBUG)
 LFLAGS := -nostdlib -z max-page-size=0x1000
 
 INC := ./inc

--- a/week5/tss/src/print.c
+++ b/week5/tss/src/print.c
@@ -93,10 +93,13 @@ static int decode_format(const char **fmt_ptr)
 		switch ((c = *fmt++)) {
 		case 'p':
 			spec |= FMT_LONG;
+			// fallthrough
 		case 'x': case 'X': case 'o':
 			spec |= c == 'o' ? FMT_OCT : FMT_HEX;
+			// fallthrough
 		case 'u':
 			spec |= FMT_UNSIGNED;
+			// fallthrough
 		case 'd': case 'i':
 			type = FMT_INT;
 			break;


### PR DESCRIPTION
Новые версии gcc стали по-умолчанию включать -fpic. Так как он конфликтует с -mcmodel=kernel, его теперь нужно явно выключать.
+ появились новые ворнинги, из-за которых нельзя было скомпилировать проект 
(так как стоит -Werror).